### PR TITLE
implement channel creation functionality

### DIFF
--- a/Connect/DataService/DataManager.swift
+++ b/Connect/DataService/DataManager.swift
@@ -70,4 +70,8 @@ class DataManager {
         }
         return allPosts
     }
+    
+    func addChannel(_ channel: Channel) {
+        channels.append(channel)
+    }
 }

--- a/Connect/View/Home/HomeViewController.swift
+++ b/Connect/View/Home/HomeViewController.swift
@@ -32,17 +32,25 @@ class HomeViewController: UIViewController, UITableViewDataSource, UITableViewDe
         return tableView
     }()
     
-    private let channels: [Channel] = DataManager.shared.getAllChannels()
+    private var channels: [Channel] {
+        return DataManager.shared.getAllChannels()
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadData), name: Notification.Name("ChannelAdded"), object: nil)
+
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(ChannelTableViewCell.self, forCellReuseIdentifier: "ChannelCell")
         tableView.separatorStyle = .none
         
         setupUI()
+    }
+    
+    @objc private func reloadData() {
+        tableView.reloadData()
     }
     
     private func setupUI() {

--- a/Connect/ViewModel/SearchViewModel.swift
+++ b/Connect/ViewModel/SearchViewModel.swift
@@ -16,6 +16,9 @@ class SearchViewModel {
     }
     
     func filterChannels(with searchText: String) -> [Channel] {
+        
+        let channels = DataManager.shared.getAllChannels()
+        
         if searchText.isEmpty {
             return channels
         } else {


### PR DESCRIPTION
Users can now create a channel from search view. Once a new channel has been created, DataManager will refresh data in both HomeView and SearchView, and the user will be taken to the newly created channel.